### PR TITLE
fix: implicitly turn on WithSuccess when a message expects a reply

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -29,6 +29,10 @@ func (w withReply) ModifyMessage(msg *message) error {
 	if err != nil {
 		return err
 	}
+	newMsg, err = toSuccessfulMessage(newMsg)
+	if err != nil {
+		return err
+	}
 	newMsg.replyTarget = w.target
 	*msg = *newMsg
 	return nil


### PR DESCRIPTION
This way, if the handler errors, the client doesn't wait for ReplyTimeout before erroring